### PR TITLE
Adjust legend marker size and padding in pie chart

### DIFF
--- a/lib/features/screens/patient/flashcards.dart
+++ b/lib/features/screens/patient/flashcards.dart
@@ -396,13 +396,13 @@ class _AreasPieChart extends StatelessWidget {
               children: areas.map((a) {
                 final idx = areas.indexOf(a) % colors.length;
                 return Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 6.0),
+                  padding: const EdgeInsets.symmetric(vertical: 4.0),
                   child: Row(
                     children: [
                       // Colored circle marker (no icon) to indicate the legend color
                       Container(
-                        width: 28,
-                        height: 28,
+                        width: 24,
+                        height: 24,
                         decoration: BoxDecoration(
                           color: colors[idx],
                           shape: BoxShape.circle,


### PR DESCRIPTION
Reduced the vertical padding and the size of the colored circle markers in the _AreasPieChart legend for a more compact layout.