### PR TITLE
Adjust dialog inset padding for wide screens

### DIFF
--- a/lib/features/screens/doctor/doctor_home_page.dart
+++ b/lib/features/screens/doctor/doctor_home_page.dart
@@ -128,9 +128,13 @@ class _DoctorHomePageState extends State<DoctorHomePage> {
             final borderColor =
                 DoctorColors.primary(isDarkMode).withOpacity(0.25);
             final iconBg = DoctorColors.primary(isDarkMode).withOpacity(0.14);
+            final screenWidth = MediaQuery.of(context).size.width;
+            final isWide = screenWidth > 800;
             return Dialog(
               backgroundColor: Colors.transparent,
-              insetPadding: const EdgeInsets.symmetric(horizontal: 24),
+              insetPadding: isWide
+                  ? EdgeInsets.symmetric(horizontal: screenWidth * 0.25)
+                  : const EdgeInsets.symmetric(horizontal: 24),
               child: Container(
                 padding: const EdgeInsets.fromLTRB(20, 18, 20, 16),
                 decoration: BoxDecoration(

--- a/lib/features/screens/patient/patient_menu_page.dart
+++ b/lib/features/screens/patient/patient_menu_page.dart
@@ -65,9 +65,13 @@ class _PatientMenuPageState extends State<PatientMenuPage> {
                 .withAlpha((0.25 * 255).round());
             final iconBg = AppColors.getPrimaryButtonColor(isDarkMode)
                 .withAlpha((0.12 * 255).round());
+            final screenWidth = MediaQuery.of(context).size.width;
+            final isWide = screenWidth > 800;
             return Dialog(
               backgroundColor: Colors.transparent,
-              insetPadding: const EdgeInsets.symmetric(horizontal: 24),
+              insetPadding: isWide
+                  ? EdgeInsets.symmetric(horizontal: screenWidth * 0.25)
+                  : const EdgeInsets.symmetric(horizontal: 24),
               child: Container(
                 padding: const EdgeInsets.fromLTRB(20, 18, 20, 16),
                 decoration: BoxDecoration(


### PR DESCRIPTION
This pull request improves the responsiveness of dialog modals on both the doctor and patient home/menu pages by adjusting their horizontal padding based on the screen width. This ensures that dialogs are better centered and have appropriate spacing on wider screens.

**Responsive dialog layout:**

* Updated the `insetPadding` of the `Dialog` widgets in both `doctor_home_page.dart` and `patient_menu_page.dart` to use larger horizontal padding (25% of screen width) when the screen is wider than 800 pixels, providing a more balanced appearance on large displays. [[1]](diffhunk://#diff-42c3d9f4f96c871bdf58b9580f60145afe72fbd28b07cad9f5bf99f06fd9c8f7R131-R137) [[2]](diffhunk://#diff-35b853292c59f211877f92d8600fb7f047874d5328a260e9b5e81cbc57bd9ffaR68-R74)Dialogs in both doctor and patient pages now use increased horizontal inset padding on screens wider than 800px, improving appearance on large displays while maintaining existing padding on smaller screens.