### PR TITLE
Conflict

### DIFF
--- a/lib/features/screens/patient/flashcards.dart
+++ b/lib/features/screens/patient/flashcards.dart
@@ -396,7 +396,7 @@ class _AreasPieChart extends StatelessWidget {
               children: areas.map((a) {
                 final idx = areas.indexOf(a) % colors.length;
                 return Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 4.0),
+                  padding: const EdgeInsets.symmetric(vertical: 6.0),
                   child: Row(
                     children: [
                       // Colored circle marker (no icon) to indicate the legend color


### PR DESCRIPTION
This pull request makes a minor UI adjustment to the `_AreasPieChart` widget in the `flashcards.dart` screen. The vertical padding for each legend item has been slightly increased for improved spacing and visual clarity.

- Increased the vertical padding in the legend items of the `_AreasPieChart` from 4.0 to 6.0 for better visual spacing.