### PR TITLE
Fix build command in deploy workflow to ensure proper APK generation

### DIFF
--- a/.github/workflows/deploy_android_release.yml
+++ b/.github/workflows/deploy_android_release.yml
@@ -31,7 +31,7 @@ jobs:
 
       # Compilamos inyectando el número de ejecución de GitHub como versión
       - name: Build APK
-        run: flutter build apk --release --split-per-abi=false --build-number=${{ github.run_number }} --dart-define=API_URL="${{ secrets.PROD_API_URL }}"
+        run: flutter build apk --release --build-number=${{ github.run_number }} --dart-define=API_URL="${{ secrets.PROD_API_URL }}"
 
       # Usamos una acción que crea la Release automáticamente
       - name: Publish to GitHub Releases


### PR DESCRIPTION
This pull request makes a minor update to the Android release workflow by removing the `--split-per-abi=false` flag from the APK build command. This simplifies the build process and may affect how APKs are generated.

- Workflow update:
  * [`.github/workflows/deploy_android_release.yml`](diffhunk://#diff-f56714ef28a561a460475b2655a74bdbbd143b790bba0143a1cd3fc417d95cf7L34-R34): Removed the `--split-per-abi=false` flag from the `flutter build apk` command, so APKs will now be built with the default ABI splitting behavior.