### PR TITLE
APK generation correction

### DIFF
--- a/.github/workflows/deploy_android_release.yml
+++ b/.github/workflows/deploy_android_release.yml
@@ -31,7 +31,7 @@ jobs:
 
       # Compilamos inyectando el número de ejecución de GitHub como versión
       - name: Build APK
-        run: flutter build apk --release --split-per-abi=false --build-number=${{ github.run_number }} --dart-define=API_URL="${{ secrets.PROD_API_URL }}"
+        run: flutter build apk --release --build-number=${{ github.run_number }} --dart-define=API_URL="${{ secrets.PROD_API_URL }}"
 
       # Usamos una acción que crea la Release automáticamente
       - name: Publish to GitHub Releases


### PR DESCRIPTION
This pull request makes a small adjustment to the Android release deployment workflow. The change removes the `--split-per-abi=false` flag from the APK build command, simplifying the build process. 

* Removed the `--split-per-abi=false` flag from the `flutter build apk` command in `.github/workflows/deploy_android_release.yml`, so the APK is now built without explicitly disabling ABI splitting.