### PR TITLE
Refactor doctor patient loading to use new API method

### DIFF
--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -327,8 +327,8 @@ class ApiService {
 
   static Future<Activity> getActivity(String name) async {
     try {
-      final uri =
-          Uri.parse('$_baseUrl/activity').replace(queryParameters: {'title': name});
+      final uri = Uri.parse('$_baseUrl/activity')
+          .replace(queryParameters: {'title': name});
 
       final response = await _sendAuthorizedRequest(
         (token, client) => client.get(
@@ -766,6 +766,36 @@ class ApiService {
       throw _apiExceptionFromResponse(
         response,
         'No s\'ha pogut eliminar l\'usuari actual.',
+      );
+    } catch (e) {
+      if (e is ApiException) rethrow;
+      throw ApiException(
+        'Error de connexió amb el servidor: ${e.toString()}',
+        0,
+      );
+    }
+  }
+
+  static Future<List<UserProfile>> getDoctorPatients() async {
+    try {
+      final response = await _sendAuthorizedRequest(
+        (token, client) => client.get(
+          Uri.parse('$_baseUrl/user/doctor/patients/mine'),
+          headers: _jsonHeaders(token),
+        ),
+      );
+
+      if (response.statusCode == 200) {
+        final List<dynamic> responseData = json.decode(response.body);
+        return responseData
+            .whereType<Map<String, dynamic>>()
+            .map((json) => UserProfile.fromJson(json))
+            .toList();
+      }
+
+      throw _apiExceptionFromResponse(
+        response,
+        'No s\'han pogut recuperar els pacients del metge.',
       );
     } catch (e) {
       if (e is ApiException) rethrow;


### PR DESCRIPTION
This pull request refactors how the doctor’s assigned patients are loaded and managed in the `DoctorHomePage`, making the process more robust and less dependent on profile data. The key improvement is the introduction of a new API method to fetch the current list of patients assigned to the doctor, which simplifies and centralizes patient retrieval logic. Error handling and state updates are also improved for a better user experience.

**Patient management improvements:**

* Added a new API method `getDoctorPatients` in `ApiService` to fetch the list of patients assigned to the currently logged-in doctor, decoupling patient retrieval from the doctor's profile data.
* Refactored `_loadAssignedPatients` in `DoctorHomePage` to use the new `getDoctorPatients` API method instead of relying on emails from the profile, and improved error handling and state management when loading patients.
* Updated patient assignment and unassignment flows to reload the patient list using the new API method after changes, ensuring the UI always reflects the latest assignments. [[1]](diffhunk://#diff-42c3d9f4f96c871bdf58b9580f60145afe72fbd28b07cad9f5bf99f06fd9c8f7L66-R66) [[2]](diffhunk://#diff-42c3d9f4f96c871bdf58b9580f60145afe72fbd28b07cad9f5bf99f06fd9c8f7L301-R313) [[3]](diffhunk://#diff-42c3d9f4f96c871bdf58b9580f60145afe72fbd28b07cad9f5bf99f06fd9c8f7L327-R339)

**Minor code style improvements:**

* Minor formatting improvement in the `getActivity` method for better readability.Replaces manual patient email management with a new ApiService.getDoctorPatients() method for loading assigned patients in DoctorHomePage. Updates patient assignment and unassignment flows to use the new approach, improving reliability and code clarity.